### PR TITLE
Automatically escapes shell arguments so PHP_BINARY works with directories that contain spaces

### DIFF
--- a/src/PhpcsDiff.php
+++ b/src/PhpcsDiff.php
@@ -232,7 +232,7 @@ class PhpcsDiff
             $this->climate->info('Using phpcs executable: ' . $exec);
         }
 
-        $exec = PHP_BINARY . ' ' . $exec;
+        $exec = escapeshellarg( PHP_BINARY ) . ' ' . $exec;
         $command = $exec . ' --report=json --standard=' . $this->standard . ' ' . implode(' ', $files);
         $output = shell_exec($command);
 


### PR DESCRIPTION
## Description
This PR uses the [escapeshellarg()](https://www.php.net/manual/en/function.escapeshellarg.php) PHP's function to escape the shell arguments so PHP_BINARY works with directories that contain spaces and other escaped.

## Connected Issue
Closes #3 

## Changelog
### Fixed
- Fixed a bug where `phpcs-diff` would fail to load in directories containing spaces.

## QA Review & Testing
1. Using macOS, create a new directory called `phpcs diff`:

```
mkdir "phpcs diff"
```

2. Clone this branch inside this directory:

```
cd "phpcs diff"
git clone -b 12-fix-php-binary-with-spaces git@github.com:tiagohillebrandt/phpcs-diff.git .
```

3. Run the `phpcs-diff` binary:

```
./bin/phpcs-diff main
```

4. The `ERROR: the "ruleset.xml" coding standard is not installed.` message should show up.