### PR TITLE
Fixes an issue where PHPCS deprecation notices would break JSON output decoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     },
     "require-dev": {
         "ext-mbstring": "*",
-        "ext-phar": "*",
         "phpunit/phpunit": "^7.5.20 || ^8.5.21 || ^9.5.10",
         "phpunit/php-code-coverage": "^9.2",
         "phpcompatibility/php-compatibility": "^9.3",

--- a/src/PhpcsDiff.php
+++ b/src/PhpcsDiff.php
@@ -204,25 +204,7 @@ class PhpcsDiff
      */
     protected function runPhpcs(array $files = [])
     {
-        $exec = null;
-        $root = dirname(__DIR__);
-
-        $locations = [
-            'vendor/bin/phpcs',
-            $root . '/../../bin/phpcs',
-            $root . '/../bin/phpcs',
-            $root . '/bin/phpcs',
-            $root . '/vendor/bin/phpcs',
-            '~/.config/composer/vendor/bin/phpcs',
-            '~/.composer/vendor/bin/phpcs',
-        ];
-
-        foreach ($locations as $location) {
-            if (is_file($location)) {
-                $exec = $location;
-                break;
-            }
-        }
+        $exec = $this->findPhpcsBinaryPath();
 
         if (!$exec) {
             return null;
@@ -240,6 +222,10 @@ class PhpcsDiff
             $this->climate->info('Running: ' . $command);
         }
 
+        // Removes everything before the first curly brace.
+        $output = preg_replace('/^[^{]*({.*)/s', '$1', $output);
+
+        // Decode the JSON output.
         $json = $output ? json_decode($output, true) : null;
         if ($json === null && $output) {
             $this->climate->error($output);
@@ -336,5 +322,36 @@ class PhpcsDiff
     {
         $this->climate->error($message);
         $this->setExitCode($exitCode);
+    }
+
+    /**
+     * Get the path to the phpcs binary.
+     *
+     * @since 3.0.1
+     *
+     * @return string|null
+     */
+    private function findPhpcsBinaryPath()
+    {
+        $exec = null;
+        $root = dirname(__DIR__);
+
+        $locations = [
+            'vendor/bin/phpcs',
+            $root . '/../../bin/phpcs',
+            $root . '/../bin/phpcs',
+            $root . '/bin/phpcs',
+            $root . '/vendor/bin/phpcs',
+            '~/.config/composer/vendor/bin/phpcs',
+            '~/.composer/vendor/bin/phpcs',
+        ];
+
+        foreach ($locations as $location) {
+            if (is_file($location)) {
+                return $location;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where PHPCS deprecation notices would break JSON output decoding.

## Connected Issue
Closes #9 

## Changelog
### Fixed
- Fixed an issue where PHPCS deprecation notices would break JSON output decoding.

## QA Review & Testing
